### PR TITLE
Implement Error for MinifyError

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 name = "minify-js"
 readme = "README.md"
 repository = "https://github.com/wilsonzlin/minify-js"
-version = "0.2.4"
+version = "0.2.5"
 
 [dependencies]
 aho-corasick = "0.7"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 name = "minify-js"
 readme = "README.md"
 repository = "https://github.com/wilsonzlin/minify-js"
-version = "0.2.5"
+version = "0.2.4"
 
 [dependencies]
 aho-corasick = "0.7"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,3 +1,5 @@
+use std::error::Error;
+use std::fmt::{Display, Formatter};
 use emit::emit_js;
 use error::SyntaxError;
 use lex::Lexer;
@@ -29,6 +31,21 @@ pub enum MinifyError {
     Syntax(SyntaxError),
     IO(io::Error),
 }
+
+impl Display for MinifyError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MinifyError::Syntax(syntax) => {
+                write!(f, "Syntax Error: {:?}", syntax)
+            }
+            MinifyError::IO(io) => {
+                write!(f, "IO Error: {}", io)
+            }
+        }
+    }
+}
+
+impl Error for MinifyError {}
 
 /// Minifies UTF-8 JavaScript code, represented as an array of bytes.
 ///


### PR DESCRIPTION
Implements the Error trait for MinifyError so it can be more seamlessly used with error crates such as `eyre` and more easily be able to be `?`'d.