### PR TITLE
Fix panic for top level if and else if

### DIFF
--- a/rust/src/minify/pass1.rs
+++ b/rust/src/minify/pass1.rs
@@ -419,7 +419,7 @@ impl<'a, 'b> Visitor<'a> for Pass1<'a, 'b> {
               .hoisted_vars
               .extend_from_slice(&alt_expr.hoisted_vars);
             // Due to normalisation, it's not possible for an `if-else` to return in either branch, because one branch would've been unwrapped.
-            assert!(cons_expr.returns && alt_expr.returns);
+            assert!(!(cons_expr.returns && alt_expr.returns));
             let test = test.take(self.ctx.session);
             let consequent = cons_expr.expression;
             let alternate = alt_expr.expression;

--- a/rust/src/minify/pass1.rs
+++ b/rust/src/minify/pass1.rs
@@ -376,7 +376,7 @@ impl<'a, 'b> Visitor<'a> for Pass1<'a, 'b> {
 
         match (cons_ok, alt_ok) {
           (true, None) => {
-            let closure_scope = scope.find_self_or_ancestor(|t| t.is_closure()).unwrap();
+            let closure_scope = scope.find_self_or_ancestor(|t| t.is_closure()).unwrap_or(scope);
             let cons_expr = process_if_branch(self.ctx.session, scope, consequent);
             let min_scope = self
               .ctx
@@ -404,7 +404,7 @@ impl<'a, 'b> Visitor<'a> for Pass1<'a, 'b> {
             }
           }
           (true, Some(true)) => {
-            let closure_scope = scope.find_self_or_ancestor(|t| t.is_closure()).unwrap();
+            let closure_scope = scope.find_self_or_ancestor(|t| t.is_closure()).unwrap_or(scope);
             let cons_expr = process_if_branch(self.ctx.session, scope, consequent);
             let alt_expr = process_if_branch(self.ctx.session, scope, alternate.as_mut().unwrap());
             let min_scope = self

--- a/rust/src/minify/pass1.rs
+++ b/rust/src/minify/pass1.rs
@@ -419,7 +419,7 @@ impl<'a, 'b> Visitor<'a> for Pass1<'a, 'b> {
               .hoisted_vars
               .extend_from_slice(&alt_expr.hoisted_vars);
             // Due to normalisation, it's not possible for an `if-else` to return in either branch, because one branch would've been unwrapped.
-            assert!(!(cons_expr.returns && alt_expr.returns));
+            assert!(cons_expr.returns == alt_expr.returns);
             let test = test.take(self.ctx.session);
             let consequent = cons_expr.expression;
             let alternate = alt_expr.expression;


### PR DESCRIPTION
Fixes #18 

Hello,

This fixes two issues I found after upgrading to 0.6.0

- When using an if statement in the global scope searching for the closure scope would fail and unwrap None. I fixed this by falling back to the current scope. This address #18
- When using an else if statement the assertion always on line 422 always fails. From the comment I think the logic should be inverted.

I believe this will also fix the failed benchmark action on the 0.6.0 release.

Thanks for making this crate :)